### PR TITLE
Github pages does not auto link urls

### DIFF
--- a/practices/ci.md
+++ b/practices/ci.md
@@ -1,5 +1,5 @@
 # Continuous Integration
 
-For projects we host, we use travis-ci.org for our CI builds whenever possible. See https://travis-ci.org/curationexperts for the current list.
+We use travis-ci.org for our CI builds whenever possible. See [https://travis-ci.org/curationexperts](https://travis-ci.org/curationexperts) for the current list.
 
 We also believe that CI is a value, and an attitude, not just a task. Read [this article](https://github.com/oreillymedia/97-things-every-agile-developer-should-know/blob/master/CI_attitude.asciidoc) for more context.


### PR DESCRIPTION
1. Simplify the intro language.
1. Make an explicit link reference so travis is linked properly on https://curationexperts.github.io/playbook/practices/ci.html