### PR TITLE
Separate internal vs. external documentation more cleanly

### DIFF
--- a/every_project/project_management.md
+++ b/every_project/project_management.md
@@ -1,14 +1,13 @@
 # Project Management and Work Tracking
 
-We prefer to use github tickets for managing issues, and a grid visualization system (currently [ZenHub](https://app.zenhub.com/workspaces/dce-in-house-5ca3a97d55cfe32f2f66b774/board?repos=86658061,107903294,109763623,135945021,105701223)) to track
-the flow of our work.
+We prefer to use github tickets for managing issues, and a grid visualization system (currently ZenHub) to track the flow of our work.
 
 In order to display all projects consistently, and so that we can have shared
 expectations and understanding of a ticket's state, we want to always use the
 same column headings in our waffle boards. These are:
 
 1. New Issues - Newly created tickets go here automatically.
-1. Unprioritized - Tickets that have not beed selected for priority at this time.
+1. Unprioritized - Tickets that have not been assigned priority at this time.
 1. Backlog - Tickets that have been priority ranked in relation to other tickets. This is the column of work we should be drawing from when we pick the next thing to work on, preferably doing higher priority tickets first.
 1. In Progress - Someone is actively working on this ticket. In order to be in-progress, it should have a name attached.
 1. Review/QA - Tickets whose work has been completed and that are ready for review and/or inclusion in a demo.


### PR DESCRIPTION
Removed link to internal zenhub -- that's on the in-house wiki.  Cleaned 
up description of "Unprioritized".